### PR TITLE
Adds a blur method and handlers.

### DIFF
--- a/jquery.cleditor.js
+++ b/jquery.cleditor.js
@@ -737,19 +737,30 @@
 
   // focus - sets focus to either the textarea or iframe
   function focus(editor) {
-    setTimeout(function() {
-      if (sourceMode(editor)) editor.$area.focus();
-      else editor.$frame[0].contentWindow.focus();
-      refreshButtons(editor);
-    }, 0);
+    var content = sourceMode(editor) ? editor.$area : editor.$frame[0].contentWindow;
+    if (jQuery.isFunction(arguments[1])) {
+      // set a trigger function for focus
+      $(content).focus(arguments[1]);
+    } else {
+      setTimeout(function() {
+        content.focus();
+        refreshButtons(editor);
+      }, 0);
+    }
   }
+
   // blur - removes focus to either the textarea or iframe
   function blur(editor) {
-    setTimeout(function() {
-      if (sourceMode(editor)) editor.$area.blur();
-      else editor.$frame[0].contentWindow.blur();
-      refreshButtons(editor);
-    }, 0);
+    var content = sourceMode(editor) ? editor.$area : editor.$frame[0].contentWindow;
+    if (jQuery.isFunction(arguments[1])) {
+      // set a trigger function for blur
+      $(content).blur(arguments[1]);
+    } else {
+      setTimeout(function() {
+        content.blur();
+        refreshButtons(editor);
+      }, 0);
+    }
   }
 
   // getRange - gets the current text range object


### PR DESCRIPTION
Hey :)

This commit adds several things:
- A _blur_ method
- Attaches _CLEDITOR_ to the iframe for easy access when focus / blur.
- Accepts handler method for _focus_ / _blur_

The handler function allows to manipulate the editor when focus or blur on content. For example, hiding the toolbar when blur and showing when focus:

```
$('#' + my_id + ' textarea').cleditor({
  width: '300px',
  height: '80px',
  controls: "bold italic underline strikethrough | font size style | color highlight removeformat"
})[0].focus(function() {
  var editor = $(this.frameElement).data('CLEDITOR');
  editor.$toolbar.show();
}).blur(function() {
  var editor = $(this.frameElement).data('CLEDITOR');
  editor.$toolbar.hide();
}).focus();
```
